### PR TITLE
Fix: Correct per-class evaluation logic

### DIFF
--- a/training/lightning_module.py
+++ b/training/lightning_module.py
@@ -388,9 +388,11 @@ class LightningModule(lightning.LightningModule):
 
             block_postfix = self.block_postfix(i)
             if log_per_class:
-                for class_idx, iou in enumerate(iou_per_class):
+                original_class_ids_ordered = list(metric.things) + list(metric.stuffs)
+                for class_tensor_idx, iou in enumerate(iou_per_class):
+                    actual_class_id = original_class_ids_ordered[class_tensor_idx]
                     self.log(
-                        f"metrics/{log_prefix}_iou_class_{class_idx}{block_postfix}",
+                        f"metrics/{log_prefix}_iou_class_{actual_class_id}{block_postfix}",
                         iou,
                     )
 
@@ -440,18 +442,20 @@ class LightningModule(lightning.LightningModule):
 
             block_postfix = self.block_postfix(i)
             if log_per_class:
-                for class_idx in range(len(pq)):
+                original_class_ids_ordered = list(metric.things) + list(metric.stuffs)
+                for class_tensor_idx in range(len(pq)):
+                    actual_class_id = original_class_ids_ordered[class_tensor_idx]
                     self.log(
-                        f"metrics/{log_prefix}_pq_class_{class_idx}{block_postfix}",
-                        pq[class_idx],
+                        f"metrics/{log_prefix}_pq_class_{actual_class_id}{block_postfix}",
+                        pq[class_tensor_idx],
                     )
                     self.log(
-                        f"metrics/{log_prefix}_sq_class_{class_idx}{block_postfix}",
-                        sq[class_idx],
+                        f"metrics/{log_prefix}_sq_class_{actual_class_id}{block_postfix}",
+                        sq[class_tensor_idx],
                     )
                     self.log(
-                        f"metrics/{log_prefix}_rq_class_{class_idx}{block_postfix}",
-                        rq[class_idx],
+                        f"metrics/{log_prefix}_rq_class_{actual_class_id}{block_postfix}",
+                        rq[class_tensor_idx],
                     )
 
             self.log(


### PR DESCRIPTION
Currently, when log_per_class is enabled, metrics such as Panoptic Quality (PQ), Segmentation Quality (SQ), and Recognition Quality (RQ) are logged using a simple sequential index for the class (e.g., _pq_class_0, _pq_class_1, etc.). This index does not directly correspond to the actual semantic class ID, making it difficult to interpret which specific class a logged metric refers to, especially if the evaluated classes are not contiguous or their order in the pq/sq/rq tensors doesn't trivially map to their semantic meaning.