### PR TITLE
Add "News" section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Leveraging large-scale pre-trained ViTs, EoMT achieves accuracy similar to state
 
 Turns out, *your ViT is secretly an image segmentation model*. EoMT shows that architectural complexity isn't necessary. For segmentation, a plain Transformer is all you need.
 
+## News
+
+- [2025-08-15]: 🚀 **EoMT is supported in [LightlyTrain](https://github.com/lightly-ai/lightly-train)!**  
+  Pre-train ViT backbones and fine-tune with EoMT in just [a few lines of code](https://docs.lightly.ai/train/stable/semantic_segmentation.html). LightlyTrain is compatible with DINOv3 models. 🚀
+
 ## 🤗 Transformers Quick Usage Example
 
 EoMT is also available on [Hugging Face Transformers](https://huggingface.co/docs/transformers/main/model_doc/eomt). To install:


### PR DESCRIPTION
Hi there, and congratulations on the great work!

We recently added support for EoMT in [LightlyTrain](https://github.com/lightly-ai/lightly-train).
Would you be interested in adding a reference to it in the README? I’ve suggested creating a News section and placing it there, but happy to adjust if you think another place is more suitable.

## Summary

This PR updates the README.md to add a News section and announce EoMT support in LightlyTrain. 

## Motivation

EoMT is highly aligned with LightlyTrain’s mission of providing ML practitioners with tools to:
- Build their own visual foundation models using self-supervised learning.
- Fine-tune these models with cutting-edge methods such as EoMT.

## Current Capabilities

- EoMT (semantic segmentation) integrated in LightlyTrain.
- Support for DINOv3 models.

## Future Plans

We plan to extend EoMT in LightlyTrain with:
- Support for multi-channel images (e.g., medical imaging, satellite imagery) for broader applications.
